### PR TITLE
fix memory leak

### DIFF
--- a/src/binaryReader.cpp
+++ b/src/binaryReader.cpp
@@ -20,17 +20,17 @@ std::vector <std::pair<Narray, byte > > binaryReader::allData(){
         label.read(&l, 1);
         labels.push_back(l);
     }
-    buffer rows, colunms;
+    buffer rows, columns;
     image.read(size.chars, 4);image.read(size.chars, 4);gmbARUMAITO(size);
     image.read(rows.chars, 4);gmbARUMAITO(rows);
-    image.read(colunms.chars, 4);gmbARUMAITO(colunms);
+    image.read(columns.chars, 4);gmbARUMAITO(columns);
     std::vector < Narray > Narrays;
     for(int a = 0; a < size.integer; a++){
-        Narray temp = Narray(colunms.integer * rows.integer, 1);
+        Narray temp = Narray(columns.integer * rows.integer, 1);
         for(register int i = 0; i < rows.integer; i++){
-            for(register int j = 0; j < colunms.integer; j++){
+            for(register int j = 0; j < columns.integer; j++){
                 image.read(&l, 1);
-                temp.values[i * colunms.integer + j][0] = ((int)((unsigned char)l))/255.0;
+                temp.at(i, j) = (l & 0xff) / 255.0;
             }
         }
         Narrays.push_back(temp);

--- a/src/data.cpp
+++ b/src/data.cpp
@@ -57,10 +57,3 @@ void Data::zeroValues(){
     biasesHidden.zeroValues();
     biasesOutput.zeroValues();
 }
-
-void Data::close(){
-    weightsHidden.close();
-    weightsOutput.close();
-    biasesHidden.close();
-    biasesOutput.close();
-}

--- a/src/data.h
+++ b/src/data.h
@@ -27,7 +27,6 @@ struct Data {
     // Dividir Data por escalar
     Data operator/ (const double &a);
 
-    void close();
     // Zera todos os elementos da Data
     void zeroValues();
 };

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -2,8 +2,8 @@
 
 void DEBUG_MATRIX(Narray a){
     for (int i = 0; i < a.row; i++) {
-        for (int j = 0; j < a.colunm; j++) {
-            std::cout << a.values[i][j] << " ";
+        for (int j = 0; j < a.column; j++) {
+            std::cout << a.at(i, j) << " ";
         } std::cout << std::endl;
     }
 }

--- a/src/doriNum.cpp
+++ b/src/doriNum.cpp
@@ -1,131 +1,102 @@
 #include "doriNum.h"
+#include <stdexcept>
+
 
 // Implementação do construtor
-Narray::Narray(unsigned int _row, unsigned int _colunm){
-    
-    // Aloca dinamicamente a matriz na memória
-    values = (double**) malloc(sizeof(double*) * _row);
-    for(register int i = 0; i < _row; i++)
-        values[i] = (double*) malloc(sizeof(double) * _colunm);
-    
-    // guarda o tamanho da matriz
-    row = _row;
-    colunm = _colunm;
-    for(register int i = 0; i < row; i++)
-        for(register int j = 0; j < colunm; j++)
-            values[i][j] = 0;
+Narray::Narray(unsigned int _row, unsigned int _column)
+    : values(_row * _column)
+    , row{_row}
+    , column{_column}
+{
 }
 
-Narray::Narray(){
-    unsigned int _row = 1;
-    unsigned int _colunm = 1;
-    // Aloca dinamicamente a matriz na memória
-    values = (double**) malloc(sizeof(double*) * _row);
-    for(register int i = 0; i < _row; i++)
-        values[i] = (double*) malloc(sizeof(double) * _colunm);
-    
-    // guarda o tamanho da matriz
-    row = _row;
-    colunm = _colunm;
-    for(register int i = 0; i < row; i++)
-        for(register int j = 0; j < colunm; j++)
-            values[i][j] = 0;
+Narray::Narray()
+    : Narray(1, 1)
+{
 }
 
-Narray::Narray(const Narray &a){
-    unsigned int _row = a.row;
-    unsigned int _colunm = a.colunm;
-    // Aloca dinamicamente a matriz na memória
-    values = (double**) malloc(sizeof(double*) * _row);
-    for(register int i = 0; i < _row; i++)
-        values[i] = (double*) malloc(sizeof(double) * _colunm);
-    
-    // guarda o tamanho da matriz
-    row = _row;
-    colunm = _colunm;
-
-    // insere valores nulos na matriz
-    for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            values[i][j] = a.values[i][j];
-        }
-    }
+Narray::Narray(const Narray &a)
+    : values(a.values)
+    , row{a.row}
+    , column{a.column}
+{
 }
 
 // Dividir a matriz por escalar
 Narray Narray::operator/ (const double &a){
-    Narray ret = Narray(row, colunm);
-    for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            ret.values[i][j] = values[i][j] / a;
-        }
-    }
+    Narray ret = Narray(row, column);
+    for (auto& d : ret.values) d /= a;
     return ret;
 }
 
 // Somar matrizes
 Narray Narray::operator+ (const Narray &a){
-    if(a.row != row || a.colunm != colunm){
-        exit(1);
+    if(a.row != row || a.column != column){
+        throw std::runtime_error("Row and column do not match for the sum of two matrices");
     }
-    Narray ret = Narray(row, colunm);
-    for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            ret.values[i][j] = a.values[i][j] + values[i][j];
-        }
-    }
+    Narray ret = Narray(row, column);
+    std::transform(values.begin(), values.end(),
+                   a.values.begin(),
+                   ret.values.begin(),
+                   std::plus<>());
     return ret;
 }
 
 // Subtrair matrizes
 Narray Narray::operator- (const Narray &a){
-    if(a.row != row || a.colunm != colunm){
-        exit(1);
+    if(a.row != row || a.column != column){
+        throw std::runtime_error("Row and column do not match for the sum of two matrices");
     }
-    Narray ret = Narray(row, colunm);
-    for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            ret.values[i][j] = a.values[i][j] - values[i][j];
-        }
-    }
+    Narray ret = Narray(row, column);
+    std::transform(a.values.begin(), a.values.end(),
+                   values.begin(),
+                   ret.values.begin(),
+                   std::minus<>());
     return ret;
 }
 
 // Mapear elementos de matrizes
 Narray Narray::operator() (double (*f)(double)){
-    Narray ret = Narray(row, colunm);
-    for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            ret.values[i][j] = f(values[i][j]);
-        }
-    }
+    Narray ret = Narray(row, column);
+    std::transform(ret.values.begin(), ret.values.end(),
+                   ret.values.begin(), f);
     return ret;
 }
 
 // Multiplicação de matrizes
 Narray Narray::operator* (const Narray &a){
-    if(std::min(colunm, row) == 1 && std::min(a.colunm, a.row) == 1){
-        int range = std::max(colunm, std::max(row, std::max(a.colunm, a.row)));
+    if(std::min(column, row) == 1 && std::min(a.column, a.row) == 1){
+        int range = std::max(column, std::max(row, std::max(a.column, a.row)));
         Narray ret = Narray(range, 1);
-        for(register int i = 0; i < range; i++)ret.values[i][0] = 1;
+        for(register int i = 0; i < range; i++) ret.at(i, 0) = 1;
 
-        if(colunm > row)for(register int i = 0; i < colunm; i++)ret.values[i][0] *= values[0][i];
-        else for(register int i = 0; i < colunm; i++)ret.values[i][0] *= values[i][0];
+        if(column > row){
+            for(register int i = 0; i < column; i++)
+                ret.at(i, 0) *= at(0, i);
+        }else{
+            for(register int i = 0; i < column; i++)
+                ret.at(i, 0) *= at(i, 0);
+        }
 
-        if(a.colunm > a.row)for(register int i = 0; i < colunm; i++)ret.values[i][0] *= a.values[0][i];
-        else for(register int i = 0; i < colunm; i++)ret.values[i][0] *= a.values[i][0];
+        if(a.column > a.row){
+            for(register int i = 0; i < column; i++)
+                ret.at(i, 0) *= a.at(0, i);
+        }else{
+            for(register int i = 0; i < column; i++)
+                ret.at(i, 0) *= a.at(i, 0);
+        }
 
         return ret;
-    }else if(colunm != a.row){
-        exit(1);
+    }else if(column != a.row){
+        throw std::runtime_error("Row and column do not match for the sum of two matrices");
     }
 
-    Narray ret = Narray(row, a.colunm);
+    Narray ret = Narray(row, a.column);
 
     for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < a.colunm; j++){
-            for(register int k = 0; k < colunm; k++){
-                ret.values[i][j] += values[i][k] * a.values[k][j];
+        for(register int j = 0; j < a.column; j++){
+            for(register int k = 0; k < column; k++){
+                ret.at(i, j) += at(i, k) * a.at(k, j);
             }
         }
     }
@@ -133,43 +104,27 @@ Narray Narray::operator* (const Narray &a){
     return ret;
 }
 
-// Definir matriz de valores
-void Narray::operator<< (double** a){
-    memcpy(values, a, sizeof(double) * row * colunm);
-}
-
-// Definir matriz de valores
-void Narray::operator>> (double** a){
-    memcpy(a, values, sizeof(double) * row * colunm);
-}
-
 // Colocar valores aleatórios entre 0 e 1 na matriz
 void Narray::randomValues(){
     srand(time(NULL));
     for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            values[i][j] = rand()/(RAND_MAX / 1);
-            values[i][j] *= rand()%2 == 0? 1 : -1;  
+        for(register int j = 0; j < column; j++){
+            at(i, j) = rand()/(RAND_MAX / 1);
+            at(i, j) *= rand()%2 == 0? 1 : -1;  
         }
     }
 }
 
 void Narray::zeroValues(){
-    for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            values[i][j] = 0;
-        }
-    }
+    values.assign(values.size(), 0.0);
 }
 
 // Soma de escalar por matriz
 Narray operator+ (const double &a, const Narray &b){
-    Narray ret = Narray(b.row, b.colunm);
-    for(register int i = 0; i < b.row; i++){
-        for(register int j = 0; j < b.colunm; j++){
-            ret.values[i][j] = b.values[i][j] + a;
-        }
-    }
+    Narray ret = Narray(b.row, b.column);
+    std::transform(b.values.begin(), b.values.end(),
+                   ret.values.begin(),
+                   [a](auto&& d) { return d + a; });
     return ret;
 }
 
@@ -180,34 +135,28 @@ Narray operator+(const Narray &a, const double &b){
 
 // Subtração de escalar por matriz
 Narray operator- (double a, Narray &b){
-    Narray ret = Narray(b.row, b.colunm);
-    for(register int i = 0; i < b.row; i++){
-        for(register int j = 0; j < b.colunm; j++){
-            ret.values[i][j] = a - b.values[i][j];
-        }
-    } 
+    Narray ret = Narray(b.row, b.column);
+    std::transform(b.values.begin(), b.values.end(),
+                   ret.values.begin(),
+                   [a](auto&& d) { return a - d; });
     return ret;
 }
 
 // Subtração de matriz por escalar
 Narray operator- (Narray &b, double a){
-    Narray ret = Narray(b.row, b.colunm);
-    for(register int i = 0; i < b.row; i++){
-        for(register int j = 0; j < b.colunm; j++){
-            ret.values[i][j] = b.values[i][j] - a;
-        }
-    } 
+    Narray ret = Narray(b.row, b.column);
+    std::transform(b.values.begin(), b.values.end(),
+                   ret.values.begin(),
+                   [a](auto&& d) { return d - a; });
     return ret;
 }
 
 // Multiplicação de escalar por matriz
 Narray operator* (const double &a, const Narray &b){
-    Narray ret = Narray(b.row, b.colunm);
-    for(register int i = 0; i < b.row; i++){
-        for(register int j = 0; j < b.colunm; j++){
-            ret.values[i][j] = a * b.values[i][j];
-        }
-    }
+    Narray ret = Narray(b.row, b.column);
+    std::transform(b.values.begin(), b.values.end(),
+                   ret.values.begin(),
+                   [a](auto&& d) { return d * a; });
     return ret;
 }
 
@@ -219,35 +168,28 @@ Narray operator* (const Narray &a, const double &b){
 // Get matrix row
 Narray Narray::getRow(int id){
     if(id < 0 || id >= row) exit(1);
-    Narray ret = Narray(1, colunm);
-    for(register int i = 0; i < colunm; i++)ret.values[0][i] = values[id][i];
+    Narray ret = Narray(1, column);
+    for(register int i = 0; i < column; i++) ret.at(0, i) = at(id, i);
     return ret;
 }
 
-// Get matrix colunm
+// Get matrix column
 Narray Narray::getColunm(int id){
-    if(id < 0 || id >= colunm) exit(1);
+    if(id < 0 || id >= column) exit(1);
     Narray ret = Narray(row, 1);
-    for(register int i = 0; i < row; i++)ret.values[i][0] = values[i][id];
+    for(register int i = 0; i < row; i++) ret.at(i, 0) = at(i, id);
     return ret;
 }
 
 // Pega a matriz transposta
 Narray Narray::transposta(){
-    Narray ret = Narray(colunm, row);
+    Narray ret = Narray(column, row);
     for(register int i = 0; i < row; i++){
-        for(register int j = 0; j < colunm; j++){
-            ret.values[j][i] = values[i][j];
+        for(register int j = i + 1; j < column; j++){
+            std::swap(ret.at(j, i), ret.at(i, j));
         }
     }
-}
-
-void Narray::close(){
-    for(register int i = 0; i < row; i++){
-        free(values[i]);
-    }
-    row = 0;
-    colunm = 0;
+    return ret;
 }
 
 double sigmoid(double val){

--- a/src/doriNum.h
+++ b/src/doriNum.h
@@ -6,19 +6,24 @@
 #include <time.h>
 #include <algorithm>
 #include <iostream>
+#include <vector>
 
 struct Narray{
 
     // Valores da matriz
-    double** values;
+    std::vector<double> values;
 
     // Quantidade de linhas e colunas
-    unsigned int row, colunm;
+    unsigned int row, column;
 
     // Construtor
-    Narray(unsigned int _row, unsigned int _colunm);
+    Narray(unsigned int _row, unsigned int _column);
     Narray();
     Narray(const Narray &a);
+
+    inline double& at(int i, int j) { return values[column * i + j]; }
+    inline double at(int i, int j) const { return values[column * i + j]; }
+
     // Operador de dividir todos os elementos por um escalar
     Narray operator/ (const double &a);
 
@@ -34,12 +39,6 @@ struct Narray{
     // Mapear valores da matriz
     Narray operator() (double (*f)(double));
 
-    // Definir matriz de valores
-    void operator<< (double** a);
-
-    // Retornar matriz de valores
-    void operator>> (double** a);
-
     // Elementos aleatórios na matriz
     void randomValues();
 
@@ -54,9 +53,6 @@ struct Narray{
 
     // Pega a matriz transposta
     Narray transposta();
-
-    // Liberar NArray
-    void close();
 };
 
 Narray operator+ (const double &a, const Narray &b);

--- a/src/inputreader.cpp
+++ b/src/inputreader.cpp
@@ -7,7 +7,7 @@ Narray InputReader::readMatrix(std::string path, int row, int column){
     Narray ret = Narray(row, column);
     for(int i = 0; i < row; i++){
         for(int j = 0; j < column; j++){
-            archive >> ret.values[i][j];
+            archive >> ret.at(i, j);
         }
     }
     archive.close();
@@ -51,8 +51,8 @@ void InputReader::fillArchive(std::string path, Narray content){
     std::ofstream archive (path.c_str());
 
     for(int i = 0; i < content.row; i++){
-        for(int j = 0; j < content.colunm; j++){
-            archive << content.values[i][j];
+        for(int j = 0; j < content.column; j++){
+            archive << content.at(i, j);
             archive << " ";
         }
         archive << "\n";

--- a/src/layer.cpp
+++ b/src/layer.cpp
@@ -22,21 +22,21 @@ Layer::Layer() {
 
 //preenche os valores de weight com os valores presentes em actual
 void Layer::fillWeight(Narray &actual){
-    if(actual.row == weight.row && actual.colunm == weight.colunm){
+    if(actual.row == weight.row && actual.column == weight.column){
         weight = actual;
     }
 }
 
 //preenche os valores de bias com os valores presentes em actual
 void Layer::fillBias(Narray &actual){
-    if(actual.row == bias.row && actual.colunm == bias.colunm){
+    if(actual.row == bias.row && actual.column == bias.column){
         bias = actual;
     }
 }
 
 //preenche os valores de value com os valores presentes em actual
 void Layer::fillValue(Narray &actual){
-    if(actual.row == value.row && actual.colunm == value.colunm){
+    if(actual.row == value.row && actual.column == value.column){
         value = actual;
     }
 }
@@ -46,11 +46,4 @@ Narray Layer::activate(Narray previousValues){
     zeta = (weight * previousValues) + bias;
     value = zeta(sigmoid);
     return value;
-}
-
-void Layer::close(){
-    weight.close();
-    bias.close();
-    zeta.close();;
-    value.close();;
 }

--- a/src/layer.h
+++ b/src/layer.h
@@ -48,6 +48,4 @@ struct Layer {
     // Funcao de ativacao dos neuronios da camada
     Narray activate(Narray previousValues);
 
-
-    void close();
 };

--- a/src/netFlow.cpp
+++ b/src/netFlow.cpp
@@ -46,8 +46,7 @@ std::string execute() {
 
     log("Iniciando print de resposta");
     std::string answer = output.print(network.output.value);
-    image.close();
-    network.close();
+
     return answer;
 }
 
@@ -97,7 +96,6 @@ void train(){
         log("Salvando as informacoes da rede");
         save(reader);
     }
-    network.close();
 }
 
 
@@ -151,13 +149,13 @@ void initializeNetwork(InputReader reader){
 
         log("Lendo informacoes de treino da rede");
         info.weightsHidden = reader.readMatrix(DATA_PATH + "weightsHidden.txt", 
-                             info.weightsHidden.row, info.weightsHidden.colunm);
+                             info.weightsHidden.row, info.weightsHidden.column);
         info.weightsOutput = reader.readMatrix(DATA_PATH + "weightsOutput.txt", 
-                             info.weightsOutput.row, info.weightsOutput.colunm);
+                             info.weightsOutput.row, info.weightsOutput.column);
         info.biasesOutput = reader.readMatrix(DATA_PATH + "biasesOutput.txt", 
-                             info.biasesOutput.row, info.biasesOutput.colunm);
+                             info.biasesOutput.row, info.biasesOutput.column);
         info.biasesHidden = reader.readMatrix(DATA_PATH + "biasesHidden.txt", 
-                             info.biasesHidden.row, info.biasesHidden.colunm);
+                             info.biasesHidden.row, info.biasesHidden.column);
 
         log("Criando rede com informacoes customizadas de treino");
         network = Network(NUM_PIXELS, SIZE_HIDDEN, info);

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -47,35 +47,35 @@ Data Network::backpropagation(Narray expected){
     // Iterar pelos neuronios da camada output
     for (int i = 0; i < output.numNeuronsThis; i++){
 
-        A_output = output.value.values[i][0];
-        Z_output = output.zeta.values[i][0];
-        y = expected.values[i][0];
+        A_output = output.value.at(i, 0);
+        Z_output = output.zeta.at(i, 0);
+        y = expected.at(i, 0);
 
         // Derivada parcial (da/dz) * (dC0/da)
         double recurrentPart = derivateSigmoid(Z_output) * 2 * (A_output - y);
         // Gerar modificacao necessaria no bias do output
-        data.biasesOutput.values[i][0] -= recurrentPart;
+        data.biasesOutput.at(i, 0) -= recurrentPart;
 
         // Iterar pelos neuronios da camada hidden
         for (int j = 0; j < hidden.numNeuronsThis; j++){
-            double W_output = output.weight.values[i][j];
-            A_hidden = hidden.value.values[j][0];
-            Z_hidden = hidden.zeta.values[j][0];
+            double W_output = output.weight.at(i, j);
+            A_hidden = hidden.value.at(j, 0);
+            Z_hidden = hidden.zeta.at(j, 0);
 
             // Guardar a mudanca necessaria para esse peso 
-            data.weightsOutput.values[i][j] -= A_hidden * recurrentPart;
+            data.weightsOutput.at(i, j) -= A_hidden * recurrentPart;
             
             double internalRecurrent = derivateSigmoid(Z_hidden) * W_output * recurrentPart;
 
             // Atualiza biases da hidden
-            data.biasesHidden.values[j][0] -= internalRecurrent;
+            data.biasesHidden.at(j, 0) -= internalRecurrent;
 
             // Iterar pelos pesos entre a camada input e hidden
             for (int k = 0; k < input.numNeuronsThis; k++){
-                A_input = input.value.values[k][0];
+                A_input = input.value.at(k, 0);
                 // (dz/dw) * (da/dz) * (dz/da) * recurrentPart
                 double calc = A_input * internalRecurrent;
-                data.weightsHidden.values[j][k] -= calc;
+                data.weightsHidden.at(j, k) -= calc;
             }
         }
     }
@@ -94,24 +94,18 @@ double Network::quadraticCost(Narray output, int expected){
     Narray expectedOutput = buildExpectedOutput(expected);
     Narray costs = expectedOutput - output;
     for (int i = 0; i < size; i++){
-    	costs.values[i][0] = costs.values[i][0] * costs.values[i][0];
+    	costs.at(i, 0) = costs.at(i, 0) * costs.at(i, 0);
     }
 
     double sumOfCosts = sumCosts(costs);
-    expectedOutput.close();
     return sumOfCosts;
 }
 
 // Cria uma matriz coluna que sera
 // a melhor resposta possivel
 Narray Network::buildExpectedOutput(int expected){
-    Narray expectedOutput = Narray(10, 1);
-
-    for (int i = 0; i < 10; i++) {
-        expectedOutput.values[i][0] = 0;
-    }
-    expectedOutput.values[expected][0] = 1.0;
-
+    Narray expectedOutput(10, 1);
+    expectedOutput.at(expected, 0) = 1.0;
     return expectedOutput;
 }
 
@@ -120,7 +114,7 @@ double Network::sumCosts(Narray costs){
     double sum = 0;
 
     for (int i = 0; i < costs.row; i++) {
-        double val = costs.values[i][0];
+        double val = costs.at(i, 0);
         sum += val;
     }
     return sum;
@@ -136,8 +130,8 @@ Data Network::minibatchEvaluation(TrainingExample minibatch[], int size){
     //double cost = 0.0;
     //double averageCost = 0.0;
 
-    Narray hiddenWeights = Narray(hidden.weight.row, hidden.weight.colunm);
-    Narray outputWeights = Narray(output.weight.row, output.weight.colunm);
+    Narray hiddenWeights = Narray(hidden.weight.row, hidden.weight.column);
+    Narray outputWeights = Narray(output.weight.row, output.weight.column);
     Narray hiddenBiases = Narray(hidden.bias.row, 1);
     Narray outputBiases = Narray(output.bias.row, 1);
 
@@ -165,12 +159,6 @@ Data Network::minibatchEvaluation(TrainingExample minibatch[], int size){
         averageDesiredChanges = averageDesiredChanges + desiredChanges;
     }
     //averageCost = averageCost / size;
-    outputBiases.close();
-    hiddenBiases.close();
-    outputWeights.close();
-    hiddenWeights.close();
-    desiredChanges.close();
-    sample.close();
     averageDesiredChanges = averageDesiredChanges / size;
 
     return averageDesiredChanges;
@@ -207,12 +195,6 @@ void Network::trainingEpoch(std::vector<TrainingExample> trainingSamples, int ba
         hidden.weight = hidden.weight + changes.weightsHidden;
         hidden.bias = hidden.bias + changes.biasesHidden;
     }
-    changes.close();
-    for (int i = 0; i < batchAmount; i++){
-        for (int j = 0; j < batchSize; j++){
-            miniBatches[i][j].close(); 
-        }
-    }
 }
 
 // Retorna a quantidade de acertos da rede neural para um conjunto
@@ -225,10 +207,10 @@ int Network::testEpoch(std::vector<TrainingExample> testSamples){
         feedfoward(test.imageData);
 
         int answer;
-        double higher = output.value.values[0][0];
+        double higher = output.value.at(0, 0);
 
         for (int i = 0; i < 10; i++) {
-            if (output.value.values[i][0] > higher) {
+            if (output.value.at(i, 0) > higher) {
                 answer = i;
             }
         }
@@ -237,10 +219,4 @@ int Network::testEpoch(std::vector<TrainingExample> testSamples){
         }
     }
     return correctAnswerCnt;
-}
-
-void Network::close(){
-    hidden.close();
-    output.close();
-    input.close();
 }

--- a/src/network.h
+++ b/src/network.h
@@ -47,6 +47,4 @@ struct Network {
     void trainingEpoch(std::vector<TrainingExample> trainingSamples, int batchSize, int batchAmount);
 
     int testEpoch(std::vector<TrainingExample> testSamples);
-
-    void close();
 };  

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -18,16 +18,16 @@ std::string Output::print(Narray activations_values) {
     double total = 0.0;
 
     for (int i = 0; i < activations_values.row; i++) {
-        total += activations_values.values[i][0];  
+        total += activations_values.at(i, 0);
     }
 
     for(int i = 0; i < activations_values.row; i++) {
-        if(activations_values.values[i][0] > bestSigmoid) {
-            bestSigmoid = activations_values.values[i][0];
+        if(activations_values.at(i, 0) > bestSigmoid) {
+            bestSigmoid = activations_values.at(i, 0);
             retNumber = i;
         }
 
-        ret += toPercentage(i, activations_values.values[i][0] * 100.0 / total);
+        ret += toPercentage(i, activations_values.at(i, 0) * 100.0 / total);
 
         if(i <= 8) {
             ret += ", ";

--- a/src/trainingExample.cpp
+++ b/src/trainingExample.cpp
@@ -11,7 +11,3 @@ TrainingExample::TrainingExample(Narray &data, unsigned int _representedValue){
 TrainingExample::TrainingExample(){
 	// TODO
 }
-
-void TrainingExample::close(){
-	imageData.close();
-}

--- a/src/trainingExample.h
+++ b/src/trainingExample.h
@@ -21,6 +21,4 @@ struct TrainingExample {
     // Construtor do exemplo de treino.
     TrainingExample(Narray &data, unsigned int _representedValue);
     TrainingExample();
-    
-    void close();
 };


### PR DESCRIPTION
I fixed the memory leaks caused by missing calls to free. See #31 

Instead of adding those free calls i rewrote parts to use std::vector. Now you never have to call free or close anywhere again, since every piece of memory is managed by object lifetime.

The memory usage is now at about 1GB of ram. No further leaks are possible.

- Avoid new/delete malloc/free and try to use things like vector.
- std::vector will zero initialize and later free the memory for you.
- There are still sections with uninitialized memory in "testEpoch"
- rand() is not totally random - on linux directly read /dev/urandom for nonblocking randomness, otherwise see std::random_device and others.
- Use "-Wall -pedantic" as additional compiler flags to reduce accidents
- There could be some sections with unnecessary copies of data. could save some time

For optimization:

- I'd not use the keyword register at every for loop and i'd mostly trust the compiler. consider the flag "-march=native" and having "-O2" or "-Os".
- I can recommend creating a callgraph using callgrind + gprof2dot to visualize and easily spot possibilities for optimization

I have also spotted some issues with that algorithm but that's something for a different PR :)